### PR TITLE
Compress ubcp folder into zip during installer build

### DIFF
--- a/_lib/nsis/ubDistBuild.nsi
+++ b/_lib/nsis/ubDistBuild.nsi
@@ -68,8 +68,10 @@ Section "Install"
   SetOutPath "C:\core\infrastructure\ubDistBuild"
   File /r "..\..\..\ubDistBuild-accessories\parts\ubDistBuild\*"
 
-  SetOutPath "C:\core\infrastructure\ubDistBuild\_local\ubcp"
-  File /r "..\..\..\ubDistBuild-accessories\parts\ubcp\package_ubcp-core\ubcp\*"
+  SetOutPath "C:\core\infrastructure\ubDistBuild\_local"
+  File "..\..\..\ubDistBuild-accessories\parts\ubcp\package_ubcp-core\ubcp.zip"
+  nsisunz::UnzipToLog "$INSTDIR\_local\ubcp.zip" "$INSTDIR\_local"
+  Delete "$INSTDIR\_local\ubcp.zip"
 
   ;ATTENTION
   Rename "C:\core\infrastructure\ubDistBuild-backup-uninstalled\_local\vm.img" "C:\core\infrastructure\ubDistBuild\_local\vm.img"

--- a/_prog/build-special.sh
+++ b/_prog/build-special.sh
@@ -211,7 +211,11 @@ _build_ubDistBuild-build() {
 
     #! type makensis && _if_cygwin && _at_userMSW_probeCmd_discoverResource-cygwinNative-ProgramFiles 'makensis' 'NSIS/bin' false
     _getMinimal-build_ubDistBuild
-    
+
+    (
+        cd "$currentAccessoriesDir"/parts/ubcp/package_ubcp-core
+        7za a -tzip -mx=9 ubcp.zip ubcp
+    )
 
     unix2dos "$scriptAbsoluteFolder"/license-installer.txt
 


### PR DESCRIPTION
## Summary
- compress the ubcp Cygwin environment into a single archive when building the installer
- expand the archive during installation rather than copying individual files

## Testing
- `bash -n _prog/build-special.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b62bf77c8832c85eae0f3959bc915