### PR TITLE
Fix NSIS packaging crash with ubcp

### DIFF
--- a/_lib/nsis/ubDistBuild.nsi
+++ b/_lib/nsis/ubDistBuild.nsi
@@ -68,8 +68,12 @@ Section "Install"
   SetOutPath "C:\core\infrastructure\ubDistBuild"
   File /r "..\..\..\ubDistBuild-accessories\parts\ubDistBuild\*"
 
-  SetOutPath "C:\core\infrastructure\ubDistBuild\_local\ubcp"
-  File /r "..\..\..\ubDistBuild-accessories\parts\ubcp\package_ubcp-core\ubcp\*"
+  SetOutPath "C:\core\infrastructure\ubDistBuild\_local"
+  File "..\..\..\ubDistBuild-accessories\integrations\ubcp\package_ubcp-core.7z"
+  SetOutPath "C:\core\infrastructure\ubDistBuild\_lib\7zip"
+  File "..\..\..\ubDistBuild-accessories\integrations\7zip\7zr.exe"
+  nsExec::ExecToLog '"C:\core\infrastructure\ubDistBuild\_lib\7zip\7zr.exe" x "C:\core\infrastructure\ubDistBuild\_local\package_ubcp-core.7z" -o"C:\core\infrastructure\ubDistBuild\_local\ubcp" -y'
+  Delete "C:\core\infrastructure\ubDistBuild\_local\package_ubcp-core.7z"
 
   ;ATTENTION
   Rename "C:\core\infrastructure\ubDistBuild-backup-uninstalled\_local\vm.img" "C:\core\infrastructure\ubDistBuild\_local\vm.img"

--- a/_prog/build-special.sh
+++ b/_prog/build-special.sh
@@ -88,6 +88,13 @@ _build_ubDistBuild-fetch() {
     7za -y x "$currentAccessoriesDir"/integrations/ubcp/package_ubcp-core.7z
     cd "$functionEntryPWD"
 
+    mkdir -p "$currentAccessoriesDir"/integrations/7zip
+    if [[ ! -e "$currentAccessoriesDir"/integrations/7zip/7zr.exe ]]
+    then
+        wget -O "$currentAccessoriesDir"/integrations/7zip/7zr.exe \
+            'https://www.7-zip.org/a/7zr.exe'
+    fi
+
 
     cd "$currentAccessoriesDir"/parts
     if [[ "$objectName" == "ubDistBuild" ]]


### PR DESCRIPTION
## Summary
- avoid NSIS segfault by packaging ubcp as an archive
- unpack ubcp at install time using 7zip
- fetch standalone 7zip binary during build

## Testing
- `./compile.sh` *(fails: _generate_lean-python: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b62bf77c8832c85eae0f3959bc915