### PR TITLE
Remove ops banner emission

### DIFF
--- a/ops.sh
+++ b/ops.sh
@@ -5,9 +5,6 @@
 # 2025.08.19 rmh Add VM-specific GRUB option 
 # 2025.08.22 rmh Fix setting of user PW, fix build action we broke 
 
-# --- banner so you can see ops.sh got sourced in the build log ---
-_messageNormal '[ops] vboxguest defer: overrides loaded'
-
 ###############################################################################
 # Preflight: tear down any stale project mounts/loops so a fresh chroot opens
 ###############################################################################


### PR DESCRIPTION
## Summary
- remove the file-scope banner emission from the ops overrides so sourcing ops.sh stays quiet

## Testing
- ./ubiquitous_bash.sh _get_fromTag_ingredientVM *(fails: GitHub API returned non-JSON release data and the download loop kept retrying)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4d7d3c30832c82c37eaa939e9874