### PR TITLE
Use HTTPS URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "_lib/ubiquitous_bash"]
-	path = _lib/ubiquitous_bash
-	url = git@github.com:mirage335-colossus/ubiquitous_bash.git
+        path = _lib/ubiquitous_bash
+        url = https://github.com/mirage335-colossus/ubiquitous_bash.git
 	shallow = true
 [submodule "_lib/flipKey"]
-	path = _lib/flipKey
-	url = git@github.com:mirage335/flipKey.git
+        path = _lib/flipKey
+        url = https://github.com/mirage335/flipKey.git


### PR DESCRIPTION
## Summary
- update the submodule URLs in `.gitmodules` to use HTTPS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b77417f8832ca6e4a2a244ae4c34