### PR TITLE
Stop passing default token to public build fetch steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,9 +168,6 @@ jobs:
         timeout-minutes: 120
         run: |
           ./ubiquitous_bash.sh _getMinimal_cloud
-        env:
-          INPUT_GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
       
       - name: _test_hash_legacy
         shell: bash
@@ -189,9 +186,6 @@ jobs:
         timeout-minutes: 120
         run: |
           ./ubiquitous_bash.sh _getMinimal-build_ubDistBuild
-        env:
-          INPUT_GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
       - name: build-fetch
         shell: bash
         timeout-minutes: 120
@@ -199,9 +193,6 @@ jobs:
           mkdir -p ../ubDistBuild-accessories/integrations/ubcp
           #curl -L -o ../ubDistBuild-accessories/integrations/ubcp/package_ubcp-core.7z  $(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/mirage335-colossus/ubiquitous_bash/releases" | jq -r ".[] | select(.name == \"internal\") | .assets[] | select(.name == \"package_ubcp-core.7z\") | .browser_download_url" | sort -n -r | head -n1)
           ./ubiquitous_bash.sh _build_ubDistBuild-fetch
-        env:
-          INPUT_GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
       - name: build-build
         shell: bash
         timeout-minutes: 120
@@ -209,9 +200,6 @@ jobs:
           rm -rf ../ubDistBuild-accessories/parts/ubcp/package_ubcp-core/ubcp
           #rm -f ../ubDistBuild-accessories/integrations/ubcp/package_ubcp-core.7z
           ./ubiquitous_bash.sh _build_ubDistBuild-build
-        env:
-          INPUT_GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
 
       - name: _hash_ubDistBuildExe
         shell: bash


### PR DESCRIPTION
## Summary
- remove the workflow token environment variables from the build-installer fetch/minimal steps so public clones default to anonymous HTTPS

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6b47fc984832cacb68a6c47cb79a3