### PR TITLE
Add df diagnostics to _createVMimage free-space guard

### DIFF
--- a/ops.sh
+++ b/ops.sh
@@ -1436,3 +1436,221 @@ CZXWXcRMTo8EmM8i4d
     return 0
   }
 fi
+
+###############################################################################
+# Override _createVMimage to emit df diagnostics on free-space failure
+###############################################################################
+if declare -f _createVMimage >/dev/null 2>&1; then
+_createVMimage() {
+	_messageNormal '##### _createVMimage'
+	
+	mkdir -p "$scriptLocal"
+	
+	#[[ "$ub_vmImage_micro" == "true" ]] && export ubVirtImageOverride="$scriptLocal"/vm-ingredient.img
+	
+	export vmImageFile="$scriptLocal"/vm.img
+	[[ "$ub_vmImage_micro" == "true" ]] && export vmImageFile="$scriptLocal"/vm-ingredient.img
+	[[ "$ubVirtImageOverride" != "" ]] && export vmImageFile="$ubVirtImageOverride"
+	
+	[[ "$ubVirtImageOverride" == "" ]] && [[ -e "$vmImageFile" ]] && _messagePlain_good 'exists: '"$vmImageFile" && return 0
+	[[ "$ubVirtImageOverride" == "" ]] && [[ -e "$scriptLocal"/vm.img ]] && _messagePlain_good 'exists: '"$scriptLocal"/vm.img && return 0
+	
+	[[ -e "$lock_open" ]]  && _messagePlain_bad 'bad: locked!' && _messageFAIL && _stop 1
+	[[ -e "$scriptLocal"/l_o ]]  && _messagePlain_bad 'bad: locked!' && _messageFAIL && _stop 1
+	
+	if [[ "$ubVirtImageOverride" == "" ]]; then
+		if ! [[ $(df --block-size=1000000000 --output=avail "$scriptLocal" | tr -dc '0-9') -gt "25" ]]; then
+			df --block-size=1000000000 "."
+			df --block-size=1000000000
+			_messageFAIL
+			_stop 1
+		fi
+	fi
+	
+	
+	
+	local imagedev
+	
+	_open
+	
+	export vmImageFile="$scriptLocal"/vm.img
+	[[ "$ub_vmImage_micro" == "true" ]] && export vmImageFile="$scriptLocal"/vm-ingredient.img
+	[[ "$ubVirtImageOverride" != "" ]] && export vmImageFile="$ubVirtImageOverride"
+	
+	
+	if [[ "$ubVirtImageOverride" == "" ]]
+	then
+		[[ -e "$vmImageFile" ]] && _messagePlain_bad 'exists: '"$vmImageFile" && _messageFAIL && _stop 1
+	
+	
+		_messageNormal 'create: '"$vmImageFile"': file'
+	
+
+		export vmSize=$(_vmsize)
+		[[ "$ub_vmImage_micro" == "true" ]] && export vmSize=$(_vmsize-micro)
+
+		
+		export vmSize_boundary=$(bc <<< "$vmSize - 1")
+		_createRawImage "$vmImageFile"
+	else
+		_messageNormal 'create: '"$vmImageFile"': device'
+
+		
+		export vmSize=$(bc <<< $(sudo -n lsblk -b --output SIZE -n -d "$vmImageFile")' / 1048576')
+		export vmSize=$(bc <<< "$vmSize - 1")
+		export vmSize_boundary=$(bc <<< "$vmSize - 1")
+	fi
+	
+	
+	_messageNormal 'partition: '"$vmImageFile"''
+	sudo -n parted --script "$vmImageFile" 'mklabel gpt'
+	
+	# Unusual.
+	#   EFI, Image/Root.
+	# Former default, only preferable if disk is strictly spinning CAV and many more bits per second with beginning tracks.
+	#   Swap, EFI, Image/Root.
+	# Compromise. May have better compatibility, may reduce CLV (and zoned CAV) speed changes from slowest tracks at beginning of some optical discs.
+	#   EFI, Swap, Image/Root.
+	# Expect <8MiB usage of EFI parition FAT32 filesystem, ~28GiB usage of Image/Root partition ext4 filesystem.
+	# 512MiB EFI, 5120MiB Swap, remainder Image/Root
+	# https://www.compuhoy.com/what-is-difference-between-bios-and-efi/
+	#  'Does EFI partition have to be first?' 'UEFI does not impose a restriction on the number or location of System Partitions that can exist on a system. (Version 2.5, p. 540.) As a practical matter, putting the ESP first is advisable because this location is unlikely to be impacted by partition moving and resizing operations.'
+	# http://blog.arainho.me/grub/gpt/arch-linux/2016/01/14/grub-on-gpt-partition.html
+	#  'at the first 2GB of the disk with toggle bios_grub used for booting'
+	
+	# CAUTION: *As DEFAULT*, must match other definitions (eg. _set_ubDistBuild , 'core.sh' , 'ops.sh' , ubiquitous_bash , etc) .
+	# NTFS, Recovery, partitions should not have set values in any other functions. Never used - documentation only.
+	# Swap, partition should only have set values in this and fstab functions. Never used elsewhere.
+	# x64-bios , raspbian , x64-efi
+	export ubVirtImage_doNotOverride="true"
+	export ubVirtPlatformOverride='x64-efi'
+	export ubVirtImageBIOS=p1
+	export ubVirtImageEFI=p2
+	export ubVirtImageNTFS=
+	export ubVirtImageRecovery=
+	export ubVirtImageSwap=p3
+	export ubVirtImageBoot=p4
+	export ubVirtImagePartition=p5
+	
+	
+	
+	
+	# ATTENTION: NOTICE: Larger EFI partition may be more compatible. Larger Swap partition may be more useful for hibernation.
+	
+	# BIOS
+	sudo -n parted --script "$vmImageFile" 'mkpart primary ext2 1MiB 2MiB'
+	sudo -n parted --script "$vmImageFile" 'set 1 bios_grub on'
+	
+	
+	# EFI
+	##sudo -n parted --script "$vmImageFile" 'mkpart EFI fat32 '"2"'MiB '"514"'MiB'
+	#sudo -n parted --script "$vmImageFile" 'mkpart EFI fat32 '"2"'MiB '"74"'MiB'
+	sudo -n parted --script "$vmImageFile" 'mkpart EFI fat32 '"2"'MiB '"42"'MiB'
+	sudo -n parted --script "$vmImageFile" 'set 2 msftdata on'
+	sudo -n parted --script "$vmImageFile" 'set 2 boot on'
+	sudo -n parted --script "$vmImageFile" 'set 2 esp on'
+	
+	
+	# Swap
+	##sudo -n parted --script "$vmImageFile" 'mkpart primary '"514"'MiB '"5633"'MiB'
+	##sudo -n parted --script "$vmImageFile" 'mkpart primary '"514"'MiB '"3073"'MiB'
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"74"'MiB '"98"'MiB'
+	sudo -n parted --script "$vmImageFile" 'mkpart primary '"42"'MiB '"44"'MiB'
+	
+	
+	# Boot
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"98"'MiB '"610"'MiB'
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"44"'MiB '"384"'MiB'
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"44"'MiB '"592"'MiB'
+	sudo -n parted --script "$vmImageFile" 'mkpart primary '"44"'MiB '"770"'MiB'
+	
+	
+	# Root
+	# WARNING: Adjust vmSize to match +1MiB .
+	# Try to keep this <23841MiB-256MiB-1MiB ( ie. <23584MiB ) (exactly 25000000000Bytes is 23841MiB ) . In practice, compression will obviate this issue, and the Live ISO may be more complete (ie. including 'accessories') for recovery purposes .
+	# https://www.mail-archive.com/kde-bugs-dist@kde.org/msg618604.html
+	#  '25025315816 bytes'   ...   'difference between the available space at the start and at the end is exactly 256M'
+	# http://fy.chalmers.se/~appro/linux/DVD+RW/Blu-ray/
+	#  '256MB'
+	# https://forum.blu-ray.com/showthread.php?t=76407
+	# https://forum.imgburn.com/topic/23120-overburn-or-truncate-for-blu-rays/
+	# Try to keep this <23GiB-1MiB . Prefer to fit two copies within 46GiB ( eg. 23296MiB == 22.75GiB ) .
+	# Try to keep this <28GiB-1MiB . Prefer to fit at least 18GiB (compressed rootfs tar, squashfs, etc) plus this 28GiB .
+	# Expect 25.75GiB may suffice ( ie. 22.75GiB+5GiB-2GiB ) (assuming 22.75GiB may have been sufficient by ~5GiB until another ~5GiB was added, and from there ~2GiB may have already been freed by other changes) .
+	# Expect 27.75GiB may suffice ( ie. 22.75GiB+5GiB-2GiB ) (assuming 22.75GiB may have been sufficient by ~5GiB until another ~5GiB was added) .
+
+	# Tested successfully.
+	# 22.75GiB-1MiB
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"610"'MiB '"23295"'MiB'
+
+	# 22.95GiB-1MiB
+	##sudo -n parted --script "$vmImageFile" 'mkpart primary '"384"'MiB '"23499"'MiB'
+
+	# 23841MiB-256MiB-1MiB -2MiB
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"384"'MiB '"23582"'MiB'
+
+	# 25.95GiB-1MiB
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"384"'MiB '"26571"'MiB'
+
+	# Tested successfully.
+	# 26.25GiB-1MiB
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"384"'MiB '"26879"'MiB'
+	
+	
+	
+	#sudo -n parted --script "$vmImageFile" 'mkpart primary '"384"'MiB '"$vmSize_boundary"'MiB'
+	sudo -n parted --script "$vmImageFile" 'mkpart primary '"770"'MiB '"$vmSize_boundary"'MiB'
+	
+	sudo -n parted --script "$vmImageFile" 'unit MiB print'
+	
+	
+	_close
+	
+	
+	# Format partitions .
+	_messageNormal 'format: '"$vmImageFile"''
+	#"$scriptAbsoluteLocation" _loopImage_sequence || _stop 1
+	! "$scriptAbsoluteLocation" _openLoop && _messagePlain_bad 'fail: _openLoop' && _messageFAIL
+	
+	mkdir -p "$globalVirtFS"
+	"$scriptAbsoluteLocation" _checkForMounts "$globalVirtFS" && _messagePlain_bad 'bad: mounted: globalVirtFS' && _messageFAIL && _stop 1
+	#local imagedev
+	imagedev=$(cat "$scriptLocal"/imagedev)
+	
+	local imagepart
+	local loopdevfs
+	
+	# Compression from btrfs may free up ~8GB . Some performance degradation may result if files with many random writes (eg. COW VM images) are used with btrfs .
+	# https://www.phoronix.com/scan.php?page=article&item=btrfs-zstd-compress&num=4
+	# https://btrfs.wiki.kernel.org/index.php/Compression
+	# https://unix.stackexchange.com/questions/394973/why-would-i-want-to-disable-copy-on-write-while-creating-qemu-images
+	# https://gist.github.com/niflostancu/03810a8167edc533b1712551d4f90a14
+	
+	# WARNING: Compression/btrfs of boot partition may cause BIOS compatibility issues.
+	imagepart="$imagedev""$ubVirtImageBoot"
+	loopdevfs=$(sudo -n blkid -s TYPE -o value "$imagepart" | tr -dc 'a-zA-Z0-9')
+	[[ "$loopdevfs" == "ext4" ]] && _stop 1
+	sudo -n mkfs.ext2 -e remount-ro -E lazy_itable_init=0,lazy_journal_init=0 -m 0 "$imagepart" || _stop 1
+	#sudo -n mkfs.btrfs --checksum xxhash -M -d single "$imagepart" || _stop 1
+	
+	imagepart="$imagedev""$ubVirtImageEFI"
+	loopdevfs=$(sudo -n blkid -s TYPE -o value "$imagepart" | tr -dc 'a-zA-Z0-9')
+	[[ "$loopdevfs" == "ext4" ]] && _stop 1
+	sudo -n mkfs.vfat -F 32 -n EFI "$imagepart" || _stop 1
+	
+	imagepart="$imagedev""$ubVirtImagePartition"
+	loopdevfs=$(sudo -n blkid -s TYPE -o value "$imagepart" | tr -dc 'a-zA-Z0-9')
+	[[ "$loopdevfs" == "ext4" ]] && _stop 1
+	#sudo -n mkfs.ext4 -e remount-ro -E lazy_itable_init=0,lazy_journal_init=0 -m 0 "$imagepart" || _stop 1
+	sudo -n mkfs.btrfs --checksum xxhash -M -d single "$imagepart" || _stop 1
+	
+	imagepart="$imagedev""$ubVirtImageSwap"
+	loopdevfs=$(sudo -n blkid -s TYPE -o value "$imagepart" | tr -dc 'a-zA-Z0-9')
+	[[ "$loopdevfs" == "ext4" ]] && _stop 1
+	sudo -n mkswap "$imagepart" || _stop 1
+	
+	#"$scriptAbsoluteLocation" _umountImage || _stop 1
+	! "$scriptAbsoluteLocation" _closeLoop && _messagePlain_bad 'fail: _closeLoop' && _messageFAIL
+	return 0
+}
+fi


### PR DESCRIPTION
## Summary
- replace the runtime patch with a full `_createVMimage` override in `ops.sh`
- emit targeted `df --block-size=1000000000` output before stopping when the free-space guard fails

## Testing
- bash -n ops.sh

------
https://chatgpt.com/codex/tasks/task_e_68d8aeb57324832caffea466b2b373af