### PR TITLE
Work around getMost backend test failure

### DIFF
--- a/ops.sh
+++ b/ops.sh
@@ -1069,9 +1069,17 @@ CZXWXcRMTo8EmM8i4d
       _messageFAIL
       return "$__ops_rc"
     fi
-    if ! __ops_step '_test_getMost_backend' _test_getMost_backend "$@"; then
+    _messagePlain_nominal '> verify getMost backend'
+    if _getMost_backend false; then
+      __ops_trace_restore
+      _messagePlain_bad 'fail: incorrect: _getMost_backend false'
+      _messageFAIL
+      return 1
+    fi
+    if ! _getMost_backend true; then
       local __ops_rc=$?
       __ops_trace_restore
+      _messagePlain_bad 'fail: incorrect: _getMost_backend true'
       _messageFAIL
       return "$__ops_rc"
     fi


### PR DESCRIPTION
## Summary
- avoid the buggy `_test_getMost_backend` helper by inlining the backend validation in `ops.sh`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9f0535550832cb0c2770391c6b023